### PR TITLE
Add attend_on_output option in beam search

### DIFF
--- a/keras_wrapper/extra/callbacks.py
+++ b/keras_wrapper/extra/callbacks.py
@@ -37,7 +37,8 @@ def checkDefaultParamsBeamSearch(params):
                       'output_max_length_depending_on_x': False,
                       'output_max_length_depending_on_x_factor': 3,
                       'output_min_length_depending_on_x': False,
-                      'output_min_length_depending_on_x_factor': 2
+                      'output_min_length_depending_on_x_factor': 2,
+                      'attend_on_output': False
                       }
 
     for k, v in params.iteritems():

--- a/keras_wrapper/model_ensemble.py
+++ b/keras_wrapper/model_ensemble.py
@@ -306,7 +306,8 @@ class BeamSearchEnsemble:
                           'output_max_length_depending_on_x': False,
                           'output_max_length_depending_on_x_factor': 3,
                           'output_min_length_depending_on_x': False,
-                          'output_min_length_depending_on_x_factor': 2
+                          'output_min_length_depending_on_x_factor': 2,
+                          'attend_on_output': False
                           }
         params = self.checkParameters(self.params, default_params)
         predictions = dict()


### PR DESCRIPTION
Allow models to attend on the already generated output, using beam search.